### PR TITLE
Improve indent rules for list/record values

### DIFF
--- a/nushell-ts-mode.el
+++ b/nushell-ts-mode.el
@@ -194,7 +194,10 @@ Provides completion suggestions at the current point."
      ((parent-is "array") parent-bol nushell-ts-mode-indent-offset)
 
      ;; Define indentation rules for list values
-     ((parent-is "val_list") parent-bol nushell-ts-mode-indent-offset)
+     ((parent-is "list_body") parent-bol nushell-ts-mode-indent-offset)
+
+     ;; Define indentation rules for record values
+     ((parent-is "record_body") parent-bol nushell-ts-mode-indent-offset)
 
      ;; Define indentation rules for expressions enclosed in parentheses
      ((parent-is "expr_parenthesized") parent-bol nushell-ts-mode-indent-offset)


### PR DESCRIPTION
As of e07ecc5, indentation rules for list values don't work properly.

In the following code snippet, typing return with cursor at `@` would start the next line at offset 0, instead of offset 2:

```text
let numbers = [@]
```

I think this is due to the use of "val_list" as a type name. Using `treesit-inspect-mode` I can see that while the `[` token is labeled "val_list", the actual parent of the largest node at the beginning of the line (i.e. the 1st argument of the matcher and anchor commands) is instead "list_body".

The same method applies to record values, using the "record_body" parent type. In the following snippet, typing return with the cursor at `@` would indent by 2 spaces as of this commit.

```text
let handle = spawn-daemon {
  id: a123
  addr: "127.0.0.1:9000"@
}
```